### PR TITLE
Test UXD ci

### DIFF
--- a/.github/workflows/ci-uxd.yml
+++ b/.github/workflows/ci-uxd.yml
@@ -136,7 +136,6 @@ jobs:
       - name: Yarn install + use local version of Mango-v3 +  run tests
         run: |
           cd ./uxd-program
-          pwd
           sed -i.bak 's/^mango.*/mango={path="..\/..\/..\/program\/",features=["no-entrypoint"]}/' ./programs/uxd/Cargo.toml
           yarn install
           chmod +x ./scripts/reset_program_id.sh

--- a/.github/workflows/ci-uxd.yml
+++ b/.github/workflows/ci-uxd.yml
@@ -1,0 +1,164 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  
+permissions:
+  contents: read
+  pull-requests: write
+  
+env:
+  solana_version: 1.8.11
+  anchor_version: 0.20.0
+  cluster: "devnet"
+  runner_wallet_path: "/home/runner/.config/solana/id.json"
+  mango_account_mm: "8fbL4156uoVYYyY9cvA6hVBBTdui9356tdKmFbkC6t6w"
+  NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps: 
+      - uses: actions/checkout@v2
+
+      # Checkout @UXDProtocol/UXD-Program, install dependencies
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+        with:
+          repository: UXDProtocol/uxd-program
+          ref: refs/heads/main
+          # GitHub's personal access token with access to repository
+          token: ${{ secrets.MANGO_CI_UXD }}
+          persist-credentials: false
+          path: ./uxd-program
+
+      # Node 14
+      - uses: actions/setup-node@v2.5.1
+        with:
+          node-version: "14"
+          cache: "yarn"
+          cache-dependency-path: ./uxd-program/yarn.lock
+          registry-url: 'https://npm.pkg.github.com'
+          scope: "@UXDProtocol"
+          always-auth: true
+          
+      # Cache Cargo registry + index.
+      - uses: actions/cache@v2
+        name: Mango - Cache Cargo registry + index
+        id: cache-anchor
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: cargo-${{ runner.os }}-v0000-${{ hashFiles('**/Cargo.lock') }}
+                
+      # Add Solana to PATH
+      - name: Add Solana to PATH
+        run: echo "/home/runner/.local/share/solana/install/active_release/bin:$PATH" >> $GITHUB_PATH
+        
+      # Cache Solana Tool Suite
+      - uses: actions/cache@v2
+        name: Cache Solana Tool Suite
+        id: cache-solana
+        with:
+          path: |
+            ~/.cache/solana/
+            ~/.local/share/solana/
+          key: solana-${{ runner.os }}-v0000-${{ env.solana_version }}
+
+      # Cache Target Folder
+      - uses: actions/cache@v2
+        name: Cache target folder
+        id: cache-programs
+        with:
+          path: |
+            ./target/debug
+            ./target/release
+            ./target/bpfel-unknown-unknown
+          key: solana-${{ runner.os }}-v0000-${{ hashFiles('**/programs/**/*.rs') }}-${{ hashFiles('**/programs/**/*.toml') }}
+
+      # Rust toolchain
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+
+      # Install Solana
+      - name: install solana
+        if: steps.cache-solana.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config build-essential libudev-dev
+          sh -c "$(curl -sSfL https://release.solana.com/v${{ env.solana_version }}/install)"
+
+      # Setup Solana
+      - name: setup solana
+        run: |
+          solana --version
+          solana config set -u d
+          solana config get
+          solana-keygen new -o ${{ env.runner_wallet_path }}
+          
+      # Checkout MangoClient-v3, install dependencies, and run MM bot devnet SOL perp + Keeper
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+        with:
+          repository: blockworks-foundation/mango-client-v3
+          path: ./mango-client-v3
+      - name: Install MangoClient-v3 dependencies then runs Mango Keeper and MM bot on devnet for SOL perp
+        run: |
+          cd ./mango-client-v3
+          yarn install
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          solana airdrop 1 -u d
+          GROUP=devnet.2 CLUSTER=${{ env.cluster }} KEYPAIR=${{ env.runner_wallet_path }} yarn keeper &
+          GROUP=devnet.2 CLUSTER=${{ env.cluster }} KEYPAIR=${{ env.runner_wallet_path }} MANGO_ACCOUNT_PUBKEY=${{ env.mango_account_mm }} MARKET=SOL yarn mm &
+          cd -
+
+
+      - name: Create NPMRC
+        run: |
+          echo "@uxdprotocol:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ env.NODE_AUTH_TOKEN }}" >> ~/.npmrc
+      - name: Yarn install + use local version of Mango-v3 +  run tests
+        run: |
+          cd ./uxd-program
+          pwd
+          sed -i.bak 's/^mango.*/mango={path="..\/..\/..\/program\/",features=["no-entrypoint"]}/' ./programs/uxd/Cargo.toml
+          yarn install
+          chmod +x ./scripts/reset_program_id.sh
+          ./scripts/reset_program_id.sh
+          npx @project-serum/anchor-cli@${{ env.anchor_version }} test --skip-local-validator
+
+#       # Runs a single command using the runners shell
+#       - name: Run a one-line script
+#         run: echo Hello, world!
+
+#       # Runs a set of commands using the runners shell
+#       - name: Run a multi-line script
+#         run: |
+#           echo Add other actions to build,
+#           echo test, and deploy your project.

--- a/.github/workflows/ci-uxd.yml
+++ b/.github/workflows/ci-uxd.yml
@@ -1,13 +1,10 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -24,7 +21,6 @@ env:
   mango_account_mm: "8fbL4156uoVYYyY9cvA6hVBBTdui9356tdKmFbkC6t6w"
   NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,8 +28,7 @@ jobs:
     steps: 
       - uses: actions/checkout@v2
 
-      # Checkout @UXDProtocol/UXD-Program, install dependencies
-      - name: Checkout
+      - name: Checkout @UXDProtocol/UXD-Program, install dependencies
         uses: actions/checkout@v2.4.0
         with:
           repository: UXDProtocol/uxd-program
@@ -43,8 +38,8 @@ jobs:
           persist-credentials: false
           path: ./uxd-program
 
-      # Node 14
       - uses: actions/setup-node@v2.5.1
+        name: Node 14 setup
         with:
           node-version: "14"
           cache: "yarn"
@@ -52,10 +47,9 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: "@UXDProtocol"
           always-auth: true
-          
-      # Cache Cargo registry + index.
+
       - uses: actions/cache@v2
-        name: Mango - Cache Cargo registry + index
+        name: Cache Cargo registry + index.
         id: cache-anchor
         with:
           path: |
@@ -65,11 +59,9 @@ jobs:
             ~/.cargo/git/db/
           key: cargo-${{ runner.os }}-v0000-${{ hashFiles('**/Cargo.lock') }}
                 
-      # Add Solana to PATH
       - name: Add Solana to PATH
         run: echo "/home/runner/.local/share/solana/install/active_release/bin:$PATH" >> $GITHUB_PATH
         
-      # Cache Solana Tool Suite
       - uses: actions/cache@v2
         name: Cache Solana Tool Suite
         id: cache-solana
@@ -79,7 +71,6 @@ jobs:
             ~/.local/share/solana/
           key: solana-${{ runner.os }}-v0000-${{ env.solana_version }}
 
-      # Cache Target Folder
       - uses: actions/cache@v2
         name: Cache target folder
         id: cache-programs
@@ -90,34 +81,32 @@ jobs:
             ./target/bpfel-unknown-unknown
           key: solana-${{ runner.os }}-v0000-${{ hashFiles('**/programs/**/*.rs') }}-${{ hashFiles('**/programs/**/*.toml') }}
 
-      # Rust toolchain
       - uses: actions-rs/toolchain@v1
+        name: Rust toolchain
         with:
           toolchain: nightly
           override: true
 
-      # Install Solana
-      - name: install solana
+      - name: Install solana
         if: steps.cache-solana.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config build-essential libudev-dev
           sh -c "$(curl -sSfL https://release.solana.com/v${{ env.solana_version }}/install)"
 
-      # Setup Solana
-      - name: setup solana
+      - name: Setup Solana
         run: |
           solana --version
           solana config set -u d
           solana config get
           solana-keygen new -o ${{ env.runner_wallet_path }}
           
-      # Checkout MangoClient-v3, install dependencies, and run MM bot devnet SOL perp + Keeper
-      - name: Checkout
+      - name: Checkout MangoClient-v3, install dependencies, and run MM bot devnet SOL perp + Keeper
         uses: actions/checkout@v2.4.0
         with:
           repository: blockworks-foundation/mango-client-v3
           path: ./mango-client-v3
+
       - name: Install MangoClient-v3 dependencies then runs Mango Keeper and MM bot on devnet for SOL perp
         run: |
           cd ./mango-client-v3
@@ -143,6 +132,7 @@ jobs:
         run: |
           echo "@uxdprotocol:registry=https://npm.pkg.github.com" >> ~/.npmrc
           echo "//npm.pkg.github.com/:_authToken=${{ env.NODE_AUTH_TOKEN }}" >> ~/.npmrc
+
       - name: Yarn install + use local version of Mango-v3 +  run tests
         run: |
           cd ./uxd-program
@@ -152,13 +142,3 @@ jobs:
           chmod +x ./scripts/reset_program_id.sh
           ./scripts/reset_program_id.sh
           npx @project-serum/anchor-cli@${{ env.anchor_version }} test --skip-local-validator
-
-#       # Runs a single command using the runners shell
-#       - name: Run a one-line script
-#         run: echo Hello, world!
-
-#       # Runs a set of commands using the runners shell
-#       - name: Run a multi-line script
-#         run: |
-#           echo Add other actions to build,
-#           echo test, and deploy your project.

--- a/.github/workflows/ci-uxd.yml
+++ b/.github/workflows/ci-uxd.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, v.** ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, v.** ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This is not optimal but would help prevent breaking UXD-Program that rely on mango to work.

In the future I think it would be better to have all the mango related code in the mango repository, so that it's the single source of truth and there is no possible composability problems

Will need add a PAT in the Mango repo secrets to access the private UXD-program repo

<img width="1241" alt="Screenshot 2022-01-11 at 12 43 32" src="https://user-images.githubusercontent.com/40299747/148936746-1cd0e96a-e67c-4c66-a813-c3b7ce54c40c.png">
